### PR TITLE
[Audio] 优化切换功能取消当前语音

### DIFF
--- a/src/contexts/AudioContext.tsx
+++ b/src/contexts/AudioContext.tsx
@@ -30,7 +30,13 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children }) => {
   }, []);
 
   const toggleAudio = () => {
-    setAudioEnabled(!audioEnabled);
+    setAudioEnabled(prev => {
+      if (prev && speechSynthesis) {
+        // Cancel any ongoing speech when disabling audio
+        speechSynthesis.cancel();
+      }
+      return !prev;
+    });
   };
 
   const speak = (text: string) => {


### PR DESCRIPTION
## 变更说明
- 在 `AudioContext.tsx` 中更新 `toggleAudio`，关闭语音时调用 `speechSynthesis.cancel()`，确保正在播放的语音立即停止。

## 所影响的文件
- `src/contexts/AudioContext.tsx`

## 测试方式说明
- 执行 `npm install` 后尝试 `npm test`，因未配置测试脚本而失败。
- 运行 `npm run lint`，无错误仅警告。

## 是否影响其他页面
- 否

------
https://chatgpt.com/codex/tasks/task_e_683f859d29a88328afcb79845eb7f6cf